### PR TITLE
Fix Typo on Occurrences

### DIFF
--- a/src/main/java/com/bigsonata/swarm/common/stats/StatsError.java
+++ b/src/main/java/com/bigsonata/swarm/common/stats/StatsError.java
@@ -10,7 +10,7 @@ public class StatsError {
   protected String name;
   protected String method;
   protected String error;
-  protected AtomicLong occurences = new AtomicLong(0);
+  protected AtomicLong occurrences = new AtomicLong(0);
 
   public StatsError(String name, String method, String error) {
     this.name = name;
@@ -18,8 +18,8 @@ public class StatsError {
     this.error = error;
   }
 
-  public void occured() {
-    this.occurences.incrementAndGet();
+  public void occurred() {
+    this.occurrences.incrementAndGet();
   }
 
   public Map<String, Object> toMap() {
@@ -27,8 +27,7 @@ public class StatsError {
     m.put("name", this.name);
     m.put("method", this.method);
     m.put("error", this.error);
-    // there's a typo in Locust rpc protocol
-    m.put("occurences", this.occurences.get());
+    m.put("occurrences", this.occurrences.get());
     return m;
   }
 }

--- a/src/main/java/com/bigsonata/swarm/services/Stats.java
+++ b/src/main/java/com/bigsonata/swarm/services/Stats.java
@@ -98,7 +98,7 @@ public abstract class Stats implements Disposable, Initializable {
       entry = new StatsError(name, method, error);
       this.errors.put(key, entry);
     }
-    entry.occured();
+    entry.occurred();
   }
 
   public void clearAll() {


### PR DESCRIPTION
Hello! 

I was recently running into the following error when my java cron would try to record a failure, and it would completely drop my worker from locust master.

```
$ /ERROR/stderr: Traceback (most recent call last):
$ /ERROR/stderr:
$ /ERROR/stderr: File "src/gevent/greenlet.py", line 854, in gevent._greenlet.Greenlet.run
$ /ERROR/stderr:
$ /ERROR/stderr: File "/Users/jeffhall/.virtualenvs/virtenv/lib/python3.6/site-packages/locust/runners.py", line 465, in client_listener
    events.slave_report.fire(client_id=msg.node_id, data=msg.data)
$ /ERROR/stderr:
$ /ERROR/stderr: File "/Users/jeffhall/.virtualenvs/virtenv/lib/python3.6/site-packages/locust/events.py", line 34, in fire
    handler(**kwargs)
$ /ERROR/stderr:
$ /ERROR/stderr: File "/Users/jeffhall/.virtualenvs/virtenv/lib/python3.6/site-packages/locust/stats.py", line 674, in on_slave_report
    global_stats.errors[error_key] = StatsError.from_dict(error)
$ /ERROR/stderr:
$ /ERROR/stderr: File "/Users/jeffhall/.virtualenvs/virtenv/lib/python3.6/site-packages/locust/stats.py", line 627, in from_dict
    data["occurrences"]
$ /ERROR/stderr:
$ /ERROR/stderr: KeyError: 'occurrences'
$ /ERROR/stderr:
$ /ERROR/stderr: 2021-10-21T15:52:47Z
$ /ERROR/stderr:
$ /ERROR/stderr: <Greenlet at 0x10990b648: <bound method MasterLocustRunner.client_listener of <locust.runners.MasterLocustRunner object at 0x109983438>>> failed with KeyError
```

I then found this comment about a typo https://github.com/anhldbk/swarm/blob/master/src/main/java/com/bigsonata/swarm/common/stats/StatsError.java#L30 and noticed that looks like the typo has been fixed... at least in `locust 0.14.6` which is what I'm running and it looks like its been fixed since `0.12.0`! (See: https://github.com/locustio/locust/pull/1024 & https://github.com/locustio/locust/commit/f0a5f893734faeddb83860b2985010facc910d7d )

I forked and fixed up the word on the Swarm side and it seemed to help me get around my error! Figured I could offer this fix here too!
