### PR TITLE
Run on multiple locust states, update example path

### DIFF
--- a/src/main/java/com/bigsonata/swarm/Cron.java
+++ b/src/main/java/com/bigsonata/swarm/Cron.java
@@ -46,7 +46,7 @@ public abstract class Cron implements Cloneable, Runnable {
 
   @Override
   public void run() {
-    if (context.locust.isRunning()) {
+    if (!context.locust.isStopped()) {
       process();
     }
   }


### PR DESCRIPTION
I was working on something locally and I noticed that the example seemed to 'stop' working when I was running with more than one user.

It looks like the `context.locust` condition will enter into a 'Spawning' state during a test with more than one user so the test will stop processing the crons.

I returned the check back to a state it was originally in and my tests seemed to continue un-heeded.

I verified that the example continued to work when running 1 or more users